### PR TITLE
Add travis support for traefik testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "3.6"
+sudo: required
+
+install:
+  - pip install pytest-travis-fold
+  - pip install requests
+  - wget https://github.com/containous/traefik/releases/download/v1.7.0/traefik_linux-amd64
+  - sudo chmod +x traefik_linux-amd64
+  - sudo ln -s -T `pwd`/traefik_linux-amd64 /usr/local/bin/traefik
+  - ls -l /usr/local/bin
+
+script:
+  - pytest ./traefik/test_traefikPrefixRouting.py -s

--- a/traefik/test_traefikPrefixRouting.py
+++ b/traefik/test_traefikPrefixRouting.py
@@ -29,11 +29,11 @@ def test_routing():
 
     traefik        = Popen(["traefik", "-c", configFilePath],
                             stdout=PIPE)
-    defaultBackend = Popen(["python", dummyServerPath, str(defaultBackendPort)],
+    defaultBackend = Popen([sys.executable, dummyServerPath, str(defaultBackendPort)],
                             stdout=PIPE)
-    firstBackend   = Popen(["python", dummyServerPath, str(firstBackendPort)],
+    firstBackend   = Popen([sys.executable, dummyServerPath, str(firstBackendPort)],
                             stdout=PIPE)
-    secondBackend  = Popen(["python", dummyServerPath, str(secondBackendPort)],
+    secondBackend  = Popen([sys.executable, dummyServerPath, str(secondBackendPort)],
                             stdout=PIPE)
 
     try:

--- a/traefik/test_traefikPrefixRouting.py
+++ b/traefik/test_traefikPrefixRouting.py
@@ -3,6 +3,7 @@ Test
 """
 import traefikUtils
 
+import sys
 import pytest
 import requests
 

--- a/traefik/test_traefikPrefixRouting.py
+++ b/traefik/test_traefikPrefixRouting.py
@@ -8,7 +8,6 @@ import requests
 
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname, join
-from os import environ
 
 def traefikRoutesToCorrectBackend(path, expectedPort):
     baseUrl = "http://localhost:" + str(traefikUtils.getPort("traefik"))

--- a/traefik/test_traefikPrefixRouting.py
+++ b/traefik/test_traefikPrefixRouting.py
@@ -7,6 +7,8 @@ import pytest
 import requests
 
 from subprocess import Popen, PIPE
+from os.path import abspath, dirname, join
+from os import environ
 
 def traefikRoutesToCorrectBackend(path, expectedPort):
     baseUrl = "http://localhost:" + str(traefikUtils.getPort("traefik"))
@@ -23,13 +25,16 @@ def test_routing():
     firstBackendPort   = traefikUtils.getPort("firstBackend")
     secondBackendPort  = traefikUtils.getPort("secondBackend")
 
-    traefik        = Popen(["traefik", "-c traefik.toml"],
+    dummyServerPath = abspath(join(dirname(__file__), 'dummyHttpServer.py'))
+    configFilePath  = abspath(join(dirname(__file__), 'traefik.toml'))
+
+    traefik        = Popen(["traefik", "-c", configFilePath],
                             stdout=PIPE)
-    defaultBackend = Popen(["python", "dummyHttpServer.py",str(defaultBackendPort)],
+    defaultBackend = Popen(["python", dummyServerPath, str(defaultBackendPort)],
                             stdout=PIPE)
-    firstBackend   = Popen(["python", "dummyHttpServer.py", str(firstBackendPort)],
+    firstBackend   = Popen(["python", dummyServerPath, str(firstBackendPort)],
                             stdout=PIPE)
-    secondBackend  = Popen(["python", "dummyHttpServer.py", str(secondBackendPort)],
+    secondBackend  = Popen(["python", dummyServerPath, str(secondBackendPort)],
                             stdout=PIPE)
 
     try:


### PR DESCRIPTION
Hi @minrk ! I added travis support to test traefik's prefix-based routing. I activated travis on my fork and the tests pass, yay! Let me know if everything works for you too. You should be able now to link travis to the outreachy upstream repo and add the build badge.