### PR TITLE
Add some automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/pytest-plugin.yml
+++ b/.github/ISSUE_TEMPLATE/pytest-plugin.yml
@@ -65,6 +65,6 @@ body:
       label: Issue description
       description: >
         If you chose the `No` option above, please describe the best as you can the issue,
-        sharing any errors you're seeing to help us undestand the issue. 
+        sharing any errors you're seeing to help us understand the issue.
     validations:
       required: false

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates once a week. By default, this check happens on a Monday.
+      interval: "weekly"

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,0 +1,26 @@
+name: Check links
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: |
+          pip install -r docs/requirements.txt
+      - working-directory: docs
+        run: make linkcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# pre-commit is a tool to perform a predefined set of tasks manually and/or
+# automatically before git commits are made.
+#
+# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
+#
+# Common tasks
+#
+# - Run on all files:   pre-commit run --all-files
+# - Register git hooks: pre-commit install --install-hooks
+#
+repos:
+  # Autoformat: markdown, yaml
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier


### PR DESCRIPTION
- GitHub Actions workflow to check links in docs
- Dependabot config to keep GitHub Actions versions up-to-date
  - We don't (yet) pin anything in requirements.txt, so haven't enabled that yet. Can do in the future though.
- Run prettier in pre-commit for Markdown and YAML files