### PR TITLE
Add documentation on funding

### DIFF
--- a/docs/source/community-coordinator/funding.md
+++ b/docs/source/community-coordinator/funding.md
@@ -1,0 +1,74 @@
+# Funding
+
+Outreachy internships are _paid_ internships and a requirement of participating
+is that we find the money to [fund at least one intern](https://www.outreachy.org/docs/community/#funding-requirements).
+There are different approaches we can take here.
+
+## Outreachy funds: Open Science and General
+
+Outreachy itself has some funding to pay interns in the form of its
+[General fund](https://www.outreachy.org/docs/community/#funding-during-cfp)
+and [Open Science fund, backed by CZI](https://www.outreachy.org/docs/community/#open-science-funding).
+[Eligible communities](https://www.outreachy.org/docs/community/#community-types)
+are able to apply for funding for at least one intern via Outreachy from one of
+these sources.
+
+```{warning}
+As a large open source project with a lot of social capital within the data
+science world, we should be mindful not to abuse these funding options where
+possible and instead save this space for under-resourced communities.
+```
+
+## Grant writing
+
+```{note}
+As a primarily volunteer-based community, it can be difficult for anyone of us
+to regularly participate in the time-consuming efforts of grant writing. When
+such an opportunity does present itself, it is encouraged to think about whether
+including Outreachy and additional funding (suggested below) would provide
+a strategic benefit to the overall grant.
+```
+
+The other way to fund an intern is to bring the money ourselves, which in
+JupyterHub's case, is likely in the form of a grant. Alongside the listed salary
+of an Outreachy intern, we should consider budgeting for the following additional
+expenses.
+
+### Paying mentors
+
+Members of our community are very busy and often cannot justify spending more
+voluntary time to mentor an intern. While not a whole solution to this
+problem, those who are able to accept payment should be recompensed fairly
+for their time.
+
+Outreachy sets out expected working hours per week throughout the various stages
+of the process in their [mentor documentation](https://www.outreachy.org/mentor/#mentor)
+and this can be used to calculate a fair salary for mentors.
+
+### Discretionary fund
+
+A discretionary fund to cover related expenses is also advised. Some line items
+that could be covered by this fund include:
+
+- **[](partners:ols:mentor-training):** Roughly between $500-$1000
+- **Mentor honoraria:** If it is not within the scope of the grant to also pay
+  mentors, or the mentors are unable to accept formal payment, then some
+  budget for honoraria to thank them for their time and expertise is
+  encouraged. An example of how mentor honoraria have been distributed in
+  [](partners:ols) is offering a choice between:
+  - A ~$50 face value gift voucher for a store such as
+    [Red Bubble](https://www.redbubble.com/), or
+  - [Planting a tree](https://tree-nation.com/) in their name
+- **Contracting folk to answer questions during the
+  [contribution period](https://www.outreachy.org/docs/community/#contribution-period):**
+  The contribution period is _intense_ and Outreachy has a few tips to
+  [avoid burnout](https://www.outreachy.org/docs/community/#avoiding-mentor-burnout-during-contribution-period)
+  during this period. Rather than solely relying on volunteers other than the
+  mentors, we could also budget to pay some people for their time to help
+  during this period.
+
+## Additional interns
+
+Sometimes mentors find themselves in the position of having more strong intern
+candidates than they have funding for. In that case, it is possible to apply
+to Outreachy for [additional intern funding](https://www.outreachy.org/docs/community/#partial-general-funding).

--- a/docs/source/community-coordinator/index.md
+++ b/docs/source/community-coordinator/index.md
@@ -6,5 +6,6 @@ Organiser for JupyterHub during an Outreachy round.
 ```{toctree}
 :maxdepth: 2
 becoming-coordinator
+funding
 partnerships
 ```

--- a/docs/source/community-coordinator/partnerships.md
+++ b/docs/source/community-coordinator/partnerships.md
@@ -6,6 +6,7 @@ learn about their best practices and develop them for the JupyterHub community's
 benefit. We also often share resources with them. These partnerships are
 detailed below.
 
+(partners:ols)=
 ## Open Life Science
 
 [Open Life Science (OLS)](https://openlifesci.org/) are an organisation
@@ -15,7 +16,8 @@ During the compilation of these guides, we have learned a lot from their
 expertise and reference their documentation where appropriate. We thank them,
 and especially [Yo Yehudi](https://yo-yehudi.com/), for their generous sharing.
 
-### Mentor Training
+(partners:ols:mentor-training)=
+### Mentor training
 
 One major way that we partner with OLS is providing training for mentors prior
 to the Outreachy internship period.

--- a/docs/source/community-coordinator/partnerships.md
+++ b/docs/source/community-coordinator/partnerships.md
@@ -7,6 +7,7 @@ benefit. We also often share resources with them. These partnerships are
 detailed below.
 
 (partners:ols)=
+
 ## Open Life Science
 
 [Open Life Science (OLS)](https://openlifesci.org/) are an organisation
@@ -17,6 +18,7 @@ expertise and reference their documentation where appropriate. We thank them,
 and especially [Yo Yehudi](https://yo-yehudi.com/), for their generous sharing.
 
 (partners:ols:mentor-training)=
+
 ### Mentor training
 
 One major way that we partner with OLS is providing training for mentors prior

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,3 +79,14 @@ html_logo = "_static/images/logo/logo.png"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# -- Options for linkcheck builder -------------------------------------------
+# ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
+
+# A list of regular expressions that match anchors Sphinx should skip when checking
+# the validity of anchors in links. Outreachy.org is a notoriously buggy website,
+# especially regarding anchors that do not redirect properly.
+
+linkcheck_ignore = [
+    "https://www.outreachy.org/docs/community/#",
+]


### PR DESCRIPTION
This PR adds documentation on funding, including:

- What funding is required to participate in Outreachy
- Where can we acquire the funding
- Extra line items to consider when grant writing for Outreachy
  - Paying mentors or providing honoraria
  - Training mentors 

related #45 