### PR TITLE
Add helper scripts: close microtask issues

### DIFF
--- a/helper-scripts/README.md
+++ b/helper-scripts/README.md
@@ -15,11 +15,11 @@ through them and post a comment thanking the applicant for their contribution,
 and then close the issue.
 
 ```{bash}
-Usage: comment-close-issues.py [OPTIONS] ISSUE_LABELS...                                           
-                                                                                                    
- Loop over a list of GitHub issues that have specific labels, leave a comment on each issue, then   
- close it.                                                                                          
-                                                                                                    
+Usage: comment-close-issues.py [OPTIONS] ISSUE_LABELS...
+
+ Loop over a list of GitHub issues that have specific labels, leave a comment on each issue, then
+ close it.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
 │ *    issue_labels      ISSUE_LABELS...  [default: None] [required]                               │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/helper-scripts/README.md
+++ b/helper-scripts/README.md
@@ -1,0 +1,32 @@
+# Helper Scripts
+
+This folder contains some helper scripts to automate some tasks related to
+Outreachy. They are primarily written in Python and all the requirements to
+run the scripts are listed in the [requirements file](./requirements.txt).
+
+## Closing microtask issues after the contribution period has closed
+
+For contribution microtasks, we may ask applicants to open issues using a
+template to demonstrate work they have done. This can lead to a lot of open
+issues open on the repo that are no longer useful once the contribution
+period has closed. The `comment-close-issues.py` script will pull a list of all
+open issues on the repo that match a list of defined labels, it will loop
+through them and post a comment thanking the applicant for their contribution,
+and then close the issue.
+
+```{bash}
+Usage: comment-close-issues.py [OPTIONS] ISSUE_LABELS...                                           
+                                                                                                    
+ Loop over a list of GitHub issues that have specific labels, leave a comment on each issue, then   
+ close it.                                                                                          
+                                                                                                    
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────╮
+│ *    issue_labels      ISSUE_LABELS...  [default: None] [required]                               │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
+│ --full-repo-name        TEXT  [default: jupyterhub/outreachy]                                    │
+│ --comment-body          TEXT  [default: Thank you for your contribution! Since the contribution  │
+│                               period is now over, we will close this issue.]                     │
+│ --help                        Show this message and exit.                                        │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+```

--- a/helper-scripts/comment-close-issues.py
+++ b/helper-scripts/comment-close-issues.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import requests
+import typer
+
+
+def construct_root_api_url(repo: str):
+    return "/".join(["https://api.github.com/repos", repo])
+
+
+def main(
+    issue_labels: list[str],
+    full_repo_name: str = "jupyterhub/outreachy",
+    comment_body: str = "Thank you for your contribution! Since the contribution period is now over, we will close this issue."
+):
+    """
+    Loop over a list of GitHub issues that have specific labels, leave a comment
+    on each issue, then close it.
+    """
+    token = os.environ.get("GITHUB_TOKEN", None)
+    if token is None:
+        raise ValueError(
+            "GITHUB_TOKEN must be set to a GitHub API token with at least read/write permissions for issues"
+        )
+
+    root_url = construct_root_api_url(full_repo_name)
+
+    # Set the HTTP headers
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+    }    
+
+    # List all issues on full_repo_name that have labels issues_labels
+    url = "/".join([root_url, "issues"])
+    params = {"labels": issue_labels, "per_page": 100}
+    all_issues = requests.get(url, params=params, headers=headers)
+    if not all_issues.ok:
+        sys.exit(
+            f"Could not list requested issues"
+            + f"\n\tStatus: {all_issues.status}"
+            + f"\n\tMessage: {all_issues.text}"
+        )
+
+    for issue in all_issues.json():
+        # Post a comment to the issue
+        resp = requests.post(
+            issue["comments_url"], json={"body": comment_body}, headers=headers
+        )
+        if not resp.ok:
+            print(
+                f"Could not comment on issue: {issue['html_url']}"
+                + f"\n\tStatus: {resp.status}"
+                + f"\n\tMessage: {resp.text}"
+                + "\nSkipping to next issue..."
+            )
+            continue
+
+        # Close the issue
+        resp = requests.patch(
+            issue["url"], json={"state": "closed"}, headers=headers
+        )
+        if not resp.ok:
+            print(
+                f"Could not close issue: {issue['html_url']}"
+                + f"\n\tStatus: {resp.status}"
+                + f"\n\tMessage: {resp.text}"
+                + "\nSkipping to next issue..."
+            )
+            continue
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/helper-scripts/requirements.txt
+++ b/helper-scripts/requirements.txt
@@ -1,0 +1,2 @@
+requests
+typer


### PR DESCRIPTION
Starts a folder to store helper scripts and adds one to close issues that match labels, e.g., microtasks opened during the contribution period.