### PR TITLE
Allow nox to use the same session for single or autobuilds of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the site live update as you work.
 1. Autobuild the documentation
 
    ```bash
-   nox -s docs-live
+   nox -s docs -- live
    ```
 
 2. Open `http://127.0.0.1:8000` in your browser to see the site in real time

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,8 @@
+"""
+A nox configuration file so that we can build the documentation easily with nox.
+- see the README.md for information about nox.
+- ref: https://nox.thea.codes
+"""
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
@@ -13,10 +18,19 @@ def install_deps(session):
 @nox.session(venv_backend="conda")
 def docs(session):
     install_deps(session)
-    session.run("sphinx-build", *BUILD_COMMAND)
 
+    if "live" in session.posargs:
+        # Add relative paths here if we ever need to ignore them during autobuilds
+        AUTOBUILD_IGNORE = [
+            "docs/_build",
+        ]
 
-@nox.session(name="docs-live", venv_backend="conda")
-def docs_live(session):
-    install_deps(session)
-    session.run("sphinx-autobuild", *BUILD_COMMAND)
+        cmd = ["sphinx-autobuild"]
+        for folder in AUTOBUILD_IGNORE:
+            cmd.extend(["--ignore", f"*/{folder}/*"])
+
+        cmd.extend(BUILD_COMMAND)
+        session.run(*cmd)
+
+    else:
+        session.run("sphinx-build", *BUILD_COMMAND)


### PR DESCRIPTION
Saves time since the two commands share an env and it won't have to be recreated when switching between `nox -s docs` and `nox -s docs -- live`