### PR TITLE
Intern Guide: Preparing the final application

### DIFF
--- a/docs/source/interns/index.md
+++ b/docs/source/interns/index.md
@@ -1,1 +1,14 @@
 # Intern Guide
+
+This guide should contain everything about the Outreachy application process and
+internship for applicants/interns _that is specific to the JupyterHub community_.
+Please make sure you also read Outreachy's
+[Applicant guide](https://www.outreachy.org/docs/applicant/)
+and [Internship guide](https://www.outreachy.org/docs/internship/)
+for the _source of truth_ of what to expect generally.
+
+```{toctree}
+:maxdepth: 2
+
+prepare-application
+```

--- a/docs/source/interns/prepare-application.md
+++ b/docs/source/interns/prepare-application.md
@@ -1,0 +1,128 @@
+(application-prep)=
+
+# Preparing your Final Application[^1]
+
+[^1]:
+    This section is heavily inspired by application guides from
+    [Zulip](https://zulip.readthedocs.io/en/latest/outreach/apply.html) and
+    [InterMine](http://intermine.org/internships/guidance/students-applying-outreachy/).
+    Thank you for developing such awesome resources!
+
+This section contains information on how to prepare your final application
+_specifically for the JupyterHub community_.
+
+```{seealso}
+Outreachy provides their own, more general
+[guide on how to complete your Final Application](https://www.outreachy.org/docs/applicant/#final-application).
+Please make to read through this as well.
+```
+
+Your first priority during the contribution period should be figuring out how
+to become an effective contributor. Start developing your final application only
+once you have experience iterating on your pull requests to get them ready to
+merge. This way, you'll have a much better idea of how much you can accomplish
+and how you may wish to tackle your chosen project.
+
+The JupyterHub team has a fluid approach to planning, which means it is likely
+that the set of issues described in the project description and your final
+application will change over the course of the internship. That's ok! These
+documents are not a strict commitment, either from you or your mentor.
+
+(application-prep:put-together)=
+
+## Putting together your application
+
+As you compile all of the information about you to put into your application,
+you should make sure that you cover the following topics:
+
+- Why you are applying:
+  - Why you're excited about working on JupyterHub
+  - What you're hoping to get out of your participation in JupyterHub
+  - What you're hoping to get out of working on the specific project you've chosen
+- Relevant experience:
+  - Summary of your **prior experience with the technologies** used by JupyterHub,
+    for example, Python
+  - Your **prior contributions to open source projects** (including pull requests,
+    bug reports, and so on) with links, if applicable (don't worry if this is
+    your first time contributing!)
+  - Any other **materials which will help us evaluate how you work**, such as
+    links to personal or school projects, along with brief descriptions
+- Your **contributions to JupyterHub**, including pull requests, bug reports, and
+  helping others in the community (with links to all materials)
+- Your answers to the [](application-prep:put-together:comm-qs)
+- A [](application-prep:put-together:proj-outline)
+
+(application-prep:put-together:comm-qs)=
+
+### Community-specific questions
+
+Please answer these questions in the relevant section of your application:
+
+1. **In your own words, what problem is the project attempting to solve?**
+   (_50 words max_)
+2. **In your own words, what is the main goal of the project?** (_50 words max_)
+
+With the answers to these questions, you should be able to begin developing your
+[](application-prep:put-together:proj-outline).
+
+(application-prep:put-together:proj-outline)=
+
+### Project outline
+
+```{attention}
+It is not practical for us to individually help you develop a specific timeline
+for your applications. We expect you to submit a project outline as described
+here _instead of a timeline_, and will help you manage the timeline for your
+project if your application is accepted.
+```
+
+By answering the [](application-prep:put-together:comm-qs) above, you should
+have a clear idea of what the project is trying to achieve and what problems
+need to be solved in order to be successful.
+
+Your outline should include:
+
+- A clear plan of action. What are you going to actually do?
+- Milestones that are achievable and realistic
+- Things happen! We can't foresee every problem! Applications that say "I will
+  do A and B. If there is time, I will do C." are encouraged
+
+Here are a couple of successful applications to help you
+
+- [2018 GSoC applicants to InterMine](https://github.com/nupurgunwant/GSoC-Proposal)
+  - This is a little bit different from the Outreachy application, but should
+    help you generate some ideas
+
+(application-prep:get-feedback)=
+
+## Circulating your application for feedback
+
+We highly recommend sharing a rough draft of your application at least one week
+before the deadline. This gives the community members a chance to give you
+feedback and help you improve your application.
+
+- If you do not have a complete draft ready, at a minimum, we recommend providing
+  your **[](application-prep:put-together:proj-outline)** and **contributions**
+  for context
+- We recommend providing a link to a draft in an app that works in the browser
+  and allows commenting, such as [Dropbox Paper](https://www.dropbox.com/paper/start),
+  [Google Docs](https://www.google.co.uk/docs/about/), or [HackMD](https://hackmd.io)
+
+```{admonition} TODO
+We should have a one-to-many approach for applicants to share their applications
+with the JupyterHub team. We aim to maximise the number of JupyterHub community
+members who could provide feedback, without forcing applicants to share their
+applications with one another if they don't wish to.
+
+Ideally, JupyterHub would have a communal email address that these requests
+can be sent to, rather than directly to mentors. This is dependent on the
+outcome of the following issue
+<https://github.com/jupyterhub/team-compass/issues/584>
+```
+
+(application-prep:evaluation)=
+
+## How will your application be evaluated after submission?
+
+The JupyterHub mentors will follow
+[Outreachy's recommendations for evaluation](https://www.outreachy.org/docs/applicant/#contribution-evaluation).

--- a/docs/source/interns/prepare-application.md
+++ b/docs/source/interns/prepare-application.md
@@ -25,7 +25,7 @@ and how you may wish to tackle your chosen project. **It is ok if your pull
 requests have not been merged when you begin working on your final application,
 or if they are not merged before the application deadline.**
 
-```{note} What does iterating on your pull request mean?
+```{admonition} What does iterating on your pull request mean?
 When pull requests are opened on a project, other members of the community
 will review the changes and provide feedback. Sometimes it is important that
 this feedback be incorporated into the pull request before it can be merged.

--- a/docs/source/interns/prepare-application.md
+++ b/docs/source/interns/prepare-application.md
@@ -87,11 +87,13 @@ Your outline should include:
 - Things happen! We can't foresee every problem! Applications that say "I will
   do A and B. If there is time, I will do C." are encouraged
 
-Here are a couple of successful applications to help you:
+Here are a couple of successful applications to help you (Thank you to the applicants
+for sharing!):
 
 - [2018 GSoC applicants to InterMine](https://github.com/nupurgunwant/GSoC-Proposal)
   - This is a little bit different from the Outreachy application, but should
     help you generate some ideas
+- [2022 Outreachy applicant to OLS](https://docs.google.com/document/d/1CBGxozCCEdysdO-WXkmJtXchOZ3QiTUM-9jMtxqNKSg/edit?usp=sharing)
 
 (application-prep:get-feedback)=
 

--- a/docs/source/interns/prepare-application.md
+++ b/docs/source/interns/prepare-application.md
@@ -14,7 +14,7 @@ _specifically for the JupyterHub community_.
 ```{seealso}
 Outreachy provides their own, more general
 [guide on how to complete your Final Application](https://www.outreachy.org/docs/applicant/#final-application).
-Please make to read through this as well.
+Please make sure to read through this as well.
 ```
 
 Your first priority during the contribution period should be figuring out how

--- a/docs/source/interns/prepare-application.md
+++ b/docs/source/interns/prepare-application.md
@@ -87,7 +87,7 @@ Your outline should include:
 - Things happen! We can't foresee every problem! Applications that say "I will
   do A and B. If there is time, I will do C." are encouraged
 
-Here are a couple of successful applications to help you
+Here are a couple of successful applications to help you:
 
 - [2018 GSoC applicants to InterMine](https://github.com/nupurgunwant/GSoC-Proposal)
   - This is a little bit different from the Outreachy application, but should

--- a/docs/source/interns/prepare-application.md
+++ b/docs/source/interns/prepare-application.md
@@ -21,7 +21,24 @@ Your first priority during the contribution period should be figuring out how
 to become an effective contributor. Start developing your final application only
 once you have experience iterating on your pull requests to get them ready to
 merge. This way, you'll have a much better idea of how much you can accomplish
-and how you may wish to tackle your chosen project.
+and how you may wish to tackle your chosen project. **It is ok if your pull
+requests have not been merged when you begin working on your final application,
+or if they are not merged before the application deadline.**
+
+```{note} What does iterating on your pull request mean?
+When pull requests are opened on a project, other members of the community
+will review the changes and provide feedback. Sometimes it is important that
+this feedback be incorporated into the pull request before it can be merged.
+And sometimes you may be asked to make further changes once the first set of
+feedback has been addressed. This is what we mean by "iterating on your pull
+requests" - it's referring to this feedback cycle.
+
+This feedback cycle is normal behaviour is most open source communities and,
+generally speaking, maintainers try to keep the cycle short. You may be asked
+to open new issues or new pull requests to track pieces of feedback that the
+team would like to include in the future, but don't think it is necessary to
+include in your current pull request.
+```
 
 The JupyterHub team has a fluid approach to planning, which means it is likely
 that the set of issues described in the project description and your final

--- a/docs/source/interns/prepare-application.md
+++ b/docs/source/interns/prepare-application.md
@@ -78,6 +78,8 @@ Please answer these questions in the relevant section of your application:
 1. **In your own words, what problem is the project attempting to solve?**
    (_50 words max_)
 2. **In your own words, what is the main goal of the project?** (_50 words max_)
+3. **In your own words, what would need to happen for this project to be
+   successful?** (_50 words max_)
 
 With the answers to these questions, you should be able to begin developing your
 [](application-prep:put-together:proj-outline).


### PR DESCRIPTION
Add guide for preparing final application

Covers ideas discussed in our [retrospective](https://hackmd.io/@sgibson91/S1RyCF5ro), specifically around community questions and using the timeline section of the application to our advantage

relates to #45 

[Link to rendered docs](https://jupyterhub-outreachy--142.org.readthedocs.build/en/142/interns/prepare-application.html)