### PR TITLE
Community Coordinator Guide: Cohort Calls

### DIFF
--- a/docs/source/community-coordinator/cohort-calls.md
+++ b/docs/source/community-coordinator/cohort-calls.md
@@ -1,0 +1,52 @@
+(cohort-calls)=
+# Cohort Calls
+
+This section describes cohort calls, what they are, and how to run them. The
+[Community Coordinator](comm-coord) holds responsibility for organising and
+leading these calls. Therefore, it is at their descretion as to whether they
+run these sessions or not. Reasons to not run these sessions may include time
+constraints, or a small cohort.
+
+## Motivation
+
+The purpose of cohort calls is two-fold. Firstly, Outreachy interns have their
+own projects to focus on, which may not overlap with one another. The cohort
+call provides a safe space for them to interact, ask each other questions, and
+help each other out.
+
+Secondly, the cohort call provides a space to teach the interns about more
+broader open science/open source concepts and the transferable skills that
+come with them, such as code review.
+
+## How to run a cohort call
+
+Cohort calls happen once a month for the during of the internship (3 calls in
+total) and should last an hour. They include some tasks, a mix of collaborative
+and silent writing, for the interns to complete.
+
+- Ask the interns to complete some kind of scheduling poll
+  ([Doodle](https://doodle.com/), [when2meet](https://www.when2meet.com/), etc)
+  to ascertain a time for the call
+- Prepare a collaborative document ([HackMD](https://hackmd.io/),
+  [Google Doc](https://docs.google.com/), etc) before the call with the topic
+  and tasks (see the next section for templates)
+- Always start the call with a reminder of the Code of Conduct, and who the
+  interns should reach out to in case of a problem
+- Always end the call with an open Q&A session when possible
+- Use a timer to manage the time spent on the tasks (e.g.
+  [cuckoo.team](https://cuckoo.team/))
+
+## Templates for cohort calls
+
+Here are some templates for the cohort calls. These templates are available in
+the GitHub repo, but also synced to HackMD documents.
+
+- Call #1
+  - **Topic:**
+  - **Templates:**
+- Call #2
+  - **Topic:**
+  - **Templates:**
+- Call #3
+  - **Topic:** TBD
+  - **Templates:** TBD

--- a/docs/source/community-coordinator/index.md
+++ b/docs/source/community-coordinator/index.md
@@ -10,4 +10,5 @@ Organiser for JupyterHub during an Outreachy round.
 becoming-coordinator
 funding
 partnerships
+cohort-calls
 ```

--- a/docs/source/interns/during.md
+++ b/docs/source/interns/during.md
@@ -51,7 +51,7 @@ Outreachy's statement on [internship extension](https://www.outreachy.org/docs/i
 
 ## (Optional) Cohort calls
 
-You may also be invited to participate in cohort calls. These are calls designed
+You may also be invited to participate in [](cohort-calls). These are calls designed
 to bring you and other interns working on JupyterHub together to collaborate and
 learn about more broader aspects of open source, such as code review.
 


### PR DESCRIPTION
Add documentation on cohort calls, what they are, why we run them, and how to run them, including templates for calls.