### PR TITLE
Remove installation of helper script requirements from noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,6 @@ BUILD_COMMAND = ["-b", "html", "docs/source", "docs/_build/html"]
 def install_deps(session):
     session.conda_install("python=3.10")
     session.install("-r", "docs/requirements.txt")
-    session.install("-r", "helper-scripts/requirements.txt")
 
 
 @nox.session(venv_backend="conda")


### PR DESCRIPTION
This is no longer required as all build-time dependencies are now stored in docs/requirements.txt