### PR TITLE
Only run get-repos-issues.py when executing inside the RTD env

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,10 +92,14 @@ html_static_path = ["_static"]
 linkcheck_ignore = ["https://www.outreachy.org/docs/community/#", "(.*)?README.md#"]
 
 # -- Custom scripts ----------------------------------------------------------
+import os  # noqa: E402
 import subprocess  # noqa: E402
 
-# Generate tables of issues
-subprocess.run([sys.executable, "_data/get_issues/get-repo-issues.py"], check=True)
+# This script makes calls to the GitHub API, so only run it inside ReadTheDocs
+READTHEDOCS = os.environ.get("READTHEDOCS", False)
+if READTHEDOCS:
+    # Generate tables of issues
+    subprocess.run([sys.executable, "_data/get_issues/get-repo-issues.py"], check=True)
 
 # Generate tables of Outreachy interns per cohort
 subprocess.run(["python", "_data/outreachy_interns/outreachy_interns.py"], check=True)


### PR DESCRIPTION
This should reduce the number of calls we make to the GitHub API and reduce potential of being rate-limited