### PR TITLE
Switch to dirhtml builder

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
+  builder: dirhtml
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: []

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You will need a Python installation and the [`nox` package](https://nox.thea.cod
    nox -s docs
    ```
 
-   You can open the `docs/_build/html/index.html` file in your local browser to
+   You can open the `docs/_build/dirhtml/index.html` file in your local browser to
    view the site.
 
 Alternatively, you can watch the `docs` folder for changes and have a copy of

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ import nox
 
 nox.options.reuse_existing_virtualenvs = True
 
-BUILD_COMMAND = ["-b", "html", "docs/source", "docs/_build/html"]
+BUILD_COMMAND = ["-b", "dirhtml", "docs/source", "docs/_build/dirhtml"]
 
 
 def install_deps(session):


### PR DESCRIPTION
Removes `.html` from the end of all URLs